### PR TITLE
Add MuesliSwap Vault

### DIFF
--- a/dApps/MuesliSwap.json
+++ b/dApps/MuesliSwap.json
@@ -122,7 +122,11 @@
                 {
                     "id": "R1ivqT",
                     "version": 1
-                }		    
+                },
+		{
+                    "id": "MtEFqy",
+                    "version": 1
+                }
             ],
             "contractId": "MnBY" 		
         }        
@@ -399,6 +403,21 @@
                     "version": 1
                 }                
             ]
-        }	    
+        },
+        {
+            "id": "MtEFqy",
+            "name": "Vault Order",
+            "purpose": "SPEND",
+	    "type": "PLUTUS",		
+            "versions": [
+                {
+                    "version": 1,
+		    "plutusVersion": 2,          
+	            "fullScriptHash": "710454355b392202e594ce74be2f5ff9ae64c6ac0fbb45cb676f8078a2", 			
+                    "scriptHash": "0454355b392202e594ce74be2f5ff9ae64c6ac0fbb45cb676f8078a2",
+                    "contractAddress": "addr1wyz9gd2m8y3q9ev5ee6tut6llxhxf34vp7a5tjm8d7q83gsu6r426"
+                }
+            ]
+        },    
     ]
 }


### PR DESCRIPTION
Adds the new [MILK Vault](https://medium.com/@muesliswap/introducing-milk-vaults-f01975f1f6b) staking option to the total amount of staking locked MILK tokens.

The id is completely made up, adjust if necessary.